### PR TITLE
Added UV autoinstall dependencies for all remaining python scripts, n…

### DIFF
--- a/calc_spectrum_v2.py
+++ b/calc_spectrum_v2.py
@@ -2,6 +2,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
+#     "joblib",
 #     "numpy",
 #     "scikit-learn",
 # ]

--- a/repre_sample_1D.py
+++ b/repre_sample_1D.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "joblib",
+#     "numpy",
+# ]
+# ///
 # -*- coding: utf-8 -*-
 """
 Program for the selection of the most representative molecular geometries for spectra modelling.

--- a/repre_sample_2D.py
+++ b/repre_sample_2D.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "joblib",
+#     "matplotlib",
+#     "numpy",
+#     "scipy",
+# ]
+# ///
 # -*- coding: utf-8 -*-
 """
 Program for the selection of the most representative molecular geometries for spectra modelling.


### PR DESCRIPTION
I have added the uv dependancies for all .py files noting that repre_sample_1D.py is also dependant on calc_spectrum_v2.py where repre_sample_2D.py is not. These files should now auto install dependancies, when runs with uv. 

Addresses Issue #4 